### PR TITLE
rename PG_DATABASE; リファクタリングの影響が種々に及んだため。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - '80:3000'
     environment:
       RAILS_ENV: development
-      PG_DATABASE: postgres_sql
+      PG_DATABASE: postgres
       PG_PASSWORD: pass
       PG_USER: postgres
       SELENIUM_DRIVER_URL: http://selenium_chrome:4444/wd/hub


### PR DESCRIPTION
- 前回のプルリクをマージ→ `docker-compose run rails g controller XXX` を実行した結果、LocalHostがfatalエラー
- DBが無いと言われてcreateしたがエラー（createはできるが、postgres_sqlが存在しないと言われた）
- docker-compose.ymlでリネームしたPG_DATABASEが悪さしていると判断し修正
- `docker-compose build` からやり直した
- このとき、`docker-compose run ~` ではなく、 `docker exec -it app bash` と直接appコンテナのBashを叩くことで余計なコンテナが立たずに作業できた