### PR TITLE
Create/view/summary detail

### DIFF
--- a/app/assets/javascripts/summary_detail.coffee
+++ b/app/assets/javascripts/summary_detail.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/summary_detail.scss
+++ b/app/assets/stylesheets/summary_detail.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the SummaryDetail controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/summary_detail_controller.rb
+++ b/app/controllers/summary_detail_controller.rb
@@ -1,0 +1,4 @@
+class SummaryDetailController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/summary_detail_controller.rb
+++ b/app/controllers/summary_detail_controller.rb
@@ -1,4 +1,11 @@
 class SummaryDetailController < ApplicationController
   def index
+    @tasks = Task.all
+  end
+
+  def show
+    @task = Task.find(params[:id])
+    @status = ["未着手", "進行中", "完了"]
+    @priority_mark = ["", "!", "!!", "!!!"]
   end
 end

--- a/app/helpers/summary_detail_helper.rb
+++ b/app/helpers/summary_detail_helper.rb
@@ -1,0 +1,2 @@
+module SummaryDetailHelper
+end

--- a/app/views/summary_detail/index.html.erb
+++ b/app/views/summary_detail/index.html.erb
@@ -1,0 +1,2 @@
+<h1>SummaryDetail#index</h1>
+<p>Find me in app/views/summary_detail/index.html.erb</p>

--- a/app/views/summary_detail/index.html.erb
+++ b/app/views/summary_detail/index.html.erb
@@ -1,2 +1,15 @@
 <h1>SummaryDetail#index</h1>
 <p>Find me in app/views/summary_detail/index.html.erb</p>
+
+<h1>Task</h1>
+
+<ul>
+    <% @tasks.each do |task| %>
+        <li>
+            <a href="/home/<%= task.id %>">
+                <b><%= task.title %></b>
+            </a>
+            <p><%= task.description %></p>
+        </li>
+    <% end %>
+</ul>

--- a/app/views/summary_detail/show.html.erb
+++ b/app/views/summary_detail/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @task.title %></h1>
+
+<p><%= @task.description %></p>
+<p><%= @status[@task.priority] %></p>
+<p>重要度：<%= @priority_mark[@task.priority] %></p>
+<p>〆切：<%= @task.date %></p>
+<p>ラベル：<%= @task.label %></p>
+<p>作成者：<%= @task.user %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get "/home", to: "summary_detail#index"
+  get "/home/:id", to: "summary_detail#show"
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  get "/home", to: "summary_detail#index"
+
 end


### PR DESCRIPTION
- [公式Docs](https://railsguides.jp/getting_started.html#rails%E3%81%A7%E3%80%8Chello%E3%80%8D%E3%81%A8%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B)を参考にView/Controllerを生成（ `rails g controller summary_detail index --skip-routes` を実行）
- DBにseedからデモデータを入れておき、それを一括表示するページ（タイトル、説明のみ）とそこから各タスクの詳細ページへアクセスできるルーティングを実装