### PR TITLE
Create/view/login logout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -239,6 +240,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.1)
   bootstrap4-kaminari-views

--- a/app/assets/javascripts/sessions.coffee
+++ b/app/assets/javascripts/sessions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Sessions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  include SessionsHelper
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,20 @@
 class SessionsController < ApplicationController
   def new
   end
+
+  def create
+    user = User.find_by(email: params[:session][:email].downcase)
+    if user && user.authenticate(params[:session][:password])
+      log_in user
+      redirect_to tasks_path
+    else
+      flash[:danger] = 'Invalid email/password combination'
+      render 'new'
+    end
+  end
+  
+  def destroy
+    log_out
+    redirect_to login_path
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,7 +5,8 @@ class TasksController < ApplicationController
   helper_method :sort_direction, :sort_column
 
   def index
-    @tasks = Task.all.order("#{sort_column} #{sort_direction}").page(params[:page])
+    # @tasks = Task.all.order("#{sort_column} #{sort_direction}").page(params[:page])
+    @tasks = Task.where(user_id: session[:user_id]).order("#{sort_column} #{sort_direction}").page(params[:page])
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,7 @@ class TasksController < ApplicationController
   end
 
   def new
-    @task = Task.new
+    @task = Task.new(user_id: session[:user_id])
   end
 
   def create

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
   before_action :set_varbs, only: [:index, :show, :search]
   before_action :set_q, only:[:index, :search]
+  before_action :loggedin_check
   helper_method :sort_direction, :sort_column
 
   def index
@@ -97,5 +98,11 @@ class TasksController < ApplicationController
 
     def set_q
       @q = Task.ransack(params[:q])
+    end
+
+    def loggedin_check
+      if !logged_in?
+        redirect_to login_path
+      end
     end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,2 +1,21 @@
 module SessionsHelper
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def current_user
+    if session[:user_id]
+      @current_user ||= User.find_by(id: session[:user_id])
+    end
+  end
+
+  # ログイン済みなら true, してないなら false を返す
+  def logged_in?
+    !current_user.nil?  # current_userがnil = セッションが存在しない（ログインしてない）
+  end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
                     format: { with: /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i },
                     # uniqueness: true
                     uniqueness: { case_sensitive: false }    # 大文字小文字関係なく一致ないように制限（この時uniqunessは自動的にtrue扱い）
+  has_secure_password
+  validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-light bg-light mb-3">
+      <div class="container-fluid">
+        <a href="/" class="navbar-brand">Tasks</a>
+      </div>
+    </nav>
+
+    <div class="container">
+      <h1>Login</h1>
+      <% flash.each do |message_type, message| %>
+        <div class="alert alert-<%= message_type %>"><%= message %></div>
+      <% end %>
+      <hr>
+      <%= form_with scope: :session, url: login_path, local: true do |f| %>
+        <div class="form-group">
+          <%= f.label :email %>
+          <%= f.email_field :email, class: 'form-control', placeholder: "someone@example.com" %>
+        </div>
+        <div class="form-group">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: 'form-control' %>
+        </div>
+        <div>
+          <%= f.submit "Log in", class: 'btn btn-primary btn-sm btn-block mt-5' %>
+        </div>
+      <% end %>
+      
+      <p style="text-align:center; margin-top:1rem;">
+        New user? <%= link_to "Sign up now!", root_path %>
+      </p>
+    
+    </div>
+  </body>
+</html>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -70,8 +70,9 @@
   </div>
 
   <div class="form-group">
-    <%= form.label :user_id %>
-    <%= form.number_field :user_id, class: 'form-control' %>
+    <%# <%= form.label :user_id %>
+    <%# <%= form.number_field :user_id, class: 'form-control' %>
+    <%= form.hidden_field :user_id, class: 'form-control' %>
     <% task.errors.full_messages_for(:user_id).each do |message| %>
       <div><%= message %></div>
     <% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -17,10 +17,10 @@
       </div>
     </nav>
 
-    <%= search_form_for @q, url: search_tasks_path do |f| %>
-      <div class="container mb-3">
-        <%= link_to "Create New Task", new_task_path, class: 'btn btn-info btn-block mb-3' %>
-        <hr>
+    <div class="container mb-3">
+      <%= link_to "Create New Task", new_task_path, class: 'btn btn-info btn-block mb-3' %>
+      <hr>
+      <%= search_form_for @q, url: search_tasks_path do |f| %>
         <div class="row align-items-center">
           <div class="col-md-4"><%= f.search_field :title_cont, placeholder: "検索したいタイトル", class: 'form-control'%></div>
           <div class="col-md-6" style="text-align:center;">
@@ -42,9 +42,9 @@
             </div>
           </div>
           <div class="col"><%= f.submit '検索', class: 'btn btn-primary btn-sm btn-block' %></div>
-        </div>
+        <% end %>
       </div>
-    <% end %>
+    </div>
     
     <%= flash[:notice] %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -9,13 +9,18 @@
   <body>
     <nav class="navbar navbar-light bg-light mb-3">
       <div class="container-fluid">
-        <a href="/" class="navbar-brand">Tasks</a>
-        <%= link_to "Create New Task", new_task_path, class: 'btn btn-info' %>
+        <a href="/tasks" class="navbar-brand">Tasks</a>
+        <div>
+          <%= current_user.name %>
+          <%= link_to "log out", logout_path, method: :delete, class: 'btn btn-link' %>
+        </div>
       </div>
     </nav>
-    
+
     <%= search_form_for @q, url: search_tasks_path do |f| %>
       <div class="container mb-3">
+        <%= link_to "Create New Task", new_task_path, class: 'btn btn-info btn-block mb-3' %>
+        <hr>
         <div class="row align-items-center">
           <div class="col-md-4"><%= f.search_field :title_cont, placeholder: "検索したいタイトル", class: 'form-control'%></div>
           <div class="col-md-6" style="text-align:center;">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,8 @@
 ja:
   activerecord:
     errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
       models:
         task:
           attributes:
@@ -19,3 +21,6 @@ ja:
               blank: "必須項目です"
               too_long: "長すぎます（255文字以内に収めてください）"
               invalid: "正しいメールアドレスを入力してください"
+            password:
+              blank: "必須項目です" 
+              too_short: "短すぎます（6文字以上にしてください）"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,16 @@
 Rails.application.routes.draw do
   get 'users/new'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
+  
   root "tasks#index"
   resources :tasks do
     collection do
       get  "search"
-    end    
+    end
   end
 
+  # resourcesを使うフルセットルーティングはいらないので個別指定
+  get    '/login',   to: 'sessions#new'
+  post   '/login',   to: 'sessions#create'
+  delete '/logout',  to: 'sessions#destroy'
 end

--- a/db/migrate/20220913073151_add_passdigest_to_users.rb
+++ b/db/migrate/20220913073151_add_passdigest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPassdigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_13_061528) do
+ActiveRecord::Schema.define(version: 2022_09_13_073151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2022_09_13_061528) do
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "password_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 3.times do |t|
-    Task.create(
+    Task.create!(
         title: "test#{t + 1}",
         description: "これはテストです（#{t}）",
         status: t,
@@ -18,8 +18,9 @@
         label: 0, 
         user_id: t+1
     )
-    User.create(
+    User.create!(
         name: "user#{t}",
-        email: "sample#{t}@example.com"
+        email: "sample#{t}@example.com",
+        password: "hogehoge#{t}"
     )
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :user do
     name { "My Name" }
     email { "test@example.com" }
+    password {"hogehoge"}
+    password_confirmation {"hogehoge"}
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe User, type: :model do
         end
       end
 
-      "email addresses should be saved as lower-case" do
+      it "email addresses should be saved as lower-case" do
         mixed_case_email = "Foo@ExAMPle.CoM"
         create(:user, email: mixed_case_email)
         expect(mixed_case_email.downcase).to eq User.take.email
@@ -61,6 +61,19 @@ RSpec.describe User, type: :model do
         user = create(:user)
         user.email = user.email.upcase  # メアドは大文字小文字判断しないので、片方大文字にしても一致検査に引っかかるようにテスト
         expect(build(:user, email:user.email)).not_to be_valid
+      end
+
+      it "password should be present (nonblank)" do
+        user = build(:user, password: " "*6, password_confirmation: " "*6)
+        user.valid?
+        expect(user.errors[:password]).to include("必須項目です") 
+      end
+    
+      it "password should have a minimum length" do
+        sample_pass = "a" * 5
+        user = build(:user, password: sample_pass, password_confirmation: sample_pass)
+        user.valid?
+        expect(user.errors[:password]).to include("短すぎます（6文字以上にしてください）") 
       end
     end
   end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get login_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
step 22: ログインログアウト機能の実装
- ログイン実装
    - bcryptを用いたパスワードハッシュ化
    - task_controllerのbefore_actionで、ログインしてない場合はどのアクションをしようとログイン画面にリダイレクト、を実装
    - ログイン状態はsession_controllerで管理
- ログイン済みユーザーのタスクを表示
    - indexアクション時にuser_idでwhereをかけている
    - タスクの作成・編集時にユーザー情報を変更されないようHidden_formを利用
- ログアウト機能
    - ナビバーのログアウトボタン
    - sessionに保存したデータのクリアと変数の初期化

---
以下、各種ビュー

![ログイン画面](https://user-images.githubusercontent.com/43166752/191153261-32597a73-0c82-491b-a9ad-e89d34c2c523.png)

| 全タスク表示（既存処理） | ログインユーザのタスクのみ表示 |
----|----
| ![スクリーンショット 2022-09-20 11 21 09](https://user-images.githubusercontent.com/43166752/191153027-53877eb8-5fee-418b-952e-713b3da30e1c.png) | ![スクリーンショット 2022-09-20 11 19 16](https://user-images.githubusercontent.com/43166752/191152935-a9ff2877-35a8-4ece-896f-fa69e9ee8aae.png) |