### PR TITLE
Create/view/users

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,7 +30,7 @@ class TasksController < ApplicationController
     )
     """
     # タスクフィールドにフィルタを実装したため、create時に一旦それを通すよう変更
-    @task = Task.new(task_params)
+    @task = Task.new(task_params.merge(user_id: session[:user_id]))
 
     if @task.save
       redirect_to root_path
@@ -77,8 +77,7 @@ class TasksController < ApplicationController
         :status,
         :date,
         :priority,
-        :label,
-        :user_id
+        :label
       )
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,77 @@
 class UsersController < ApplicationController
-  def new
+  before_action :logged_in_user, only: [:index, :edit, :update]
+  before_action :correct_user, only: [:edit, :update]
+
+  def index
+    @users = User.all
   end
+  
+
+  def show
+    @user = User.find(session[:user_id])
+  end
+  
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      log_in @user
+      flash[:success] = "Welcome to this App!"
+      redirect_to root_url
+    else
+      flash[:error] = "Something went wrong"
+      render 'new'
+    end
+  end
+  
+  def edit
+    @user = User.find(session[:user_id])
+  end
+
+  def update
+    @user = User.find(session[:user_id])
+      if @user.update_attributes(user_params)
+        flash[:success] = "User was successfully updated"
+        redirect_to @user
+      else
+        flash[:error] = "Something went wrong"
+        render 'edit'
+      end
+  end
+
+  def destroy
+    @user = User.find(session[:user_id])
+    if @user.destroy
+      flash[:success] = 'User was successfully deleted.'
+      redirect_to users_url
+    else
+      flash[:error] = 'Something went wrong'
+      redirect_to users_url
+    end
+  end
+  
+  private
+    def user_params
+      params.require(:user).permit(
+        :name,
+        :email,
+        :password,
+        :password_confirmation
+      )
+    end
+
+    def logged_in_user
+      unless logged_in?
+        flash[:danger] = "Please log in."
+        redirect_to login_url
+      end
+    end
+
+    def correct_user
+      @user = User.find(params[:id])
+      redirect_to(root_url) unless current_user?(@user)
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,12 +3,11 @@ class UsersController < ApplicationController
   before_action :correct_user, only: [:edit, :update]
 
   def index
-    @users = User.all
+    @users = User.all.page(params[:page])
   end
   
-
   def show
-    @user = User.find(session[:user_id])
+    @user = User.find(params[:id])
   end
   
   def new
@@ -28,11 +27,11 @@ class UsersController < ApplicationController
   end
   
   def edit
-    @user = User.find(session[:user_id])
+    @user = User.find(params[:id])
   end
 
   def update
-    @user = User.find(session[:user_id])
+    @user = User.find(params[:id])
       if @user.update_attributes(user_params)
         flash[:success] = "User was successfully updated"
         redirect_to @user
@@ -43,7 +42,7 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    @user = User.find(session[:user_id])
+    @user = User.find(params[:id])
     if @user.destroy
       flash[:success] = 'User was successfully deleted.'
       redirect_to users_url

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :set_varbs, only: [:show]
   before_action :logged_in_user, only: [:index, :edit, :update]
   before_action :correct_user, only: [:edit, :update]
 
@@ -72,5 +73,10 @@ class UsersController < ApplicationController
     def correct_user
       @user = User.find(params[:id])
       redirect_to(root_url) unless current_user?(@user)
+    end
+
+    def set_varbs
+      @status = ["未着手", "作業中", "完了"]
+      @priority_mark = ["", "!", "!!", "!!!"]
     end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -18,4 +18,9 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
+
+  # 渡されたユーザがログイン済みならtrue
+  def current_user?(user)
+    user == current_user
+  end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -34,7 +34,7 @@
       <% end %>
       
       <p style="text-align:center; margin-top:1rem;">
-        New user? <%= link_to "Sign up now!", root_path %>
+        New user? <%= link_to "Sign up now!", new_user_path %>
       </p>
     
     </div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -69,15 +69,6 @@
     <% end %>
   </div>
 
-  <div class="form-group">
-    <%# <%= form.label :user_id %>
-    <%# <%= form.number_field :user_id, class: 'form-control' %>
-    <%= form.hidden_field :user_id, class: 'form-control' %>
-    <% task.errors.full_messages_for(:user_id).each do |message| %>
-      <div><%= message %></div>
-    <% end %>
-  </div>
-
   <div>
     <%= form.submit class: 'btn btn-success btn-sm btn-block mt-5' %>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -11,8 +11,8 @@
       <div class="container-fluid">
         <a href="/tasks" class="navbar-brand">Tasks</a>
         <div>
-          <%= current_user.name %>
-          <%= link_to "log out", logout_path, method: :delete, class: 'btn btn-link' %>
+          <%= link_to current_user.name, user_path(session[:user_id]), class: 'btn btn-link' %>
+          <%= link_to "log out", logout_path, method: :delete, class: 'btn btn-outline-danger' %>
         </div>
       </div>
     </nav>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_with model: user, url: url, local: true do |form| %>
+  <div class="form-group">
+    <%= form.label :name %>
+    <%= form.text_field :name, class: 'form-control', placeholder: 'ユーザー名'%>
+    <% user.errors.full_messages_for(:name).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :email %>
+    <%= form.email_field :email, class: 'form-control', placeholder: 'test@example.com' %>
+    <% user.errors.full_messages_for(:email).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :password %>
+    <%= form.password_field :password, class: 'form-control', placeholder: 'パスワード' %>
+    <% user.errors.full_messages_for(:password).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :password_confirmation %>
+    <%= form.password_field :password_confirmation, class: 'form-control', placeholder: 'パスワードの確認' %>
+    <% user.errors.full_messages_for(:password_confirmation).each do |message| %>
+      <div><%= message %></div>
+    <% end %>
+  </div>
+
+  <div>
+    <%= form.submit class: 'btn btn-success btn-sm btn-block mt-5' %>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Edit Task</title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-light bg-light mb-3">
+      <div class="container-fluid">
+        <a href="/" class="navbar-brand">Tasks</a>
+        <div>
+          <%= link_to current_user.name, user_path(session[:user_id]), class: 'btn btn-link' %>
+          <%= link_to "log out", logout_path, method: :delete, class: 'btn btn-outline-danger' %>
+        </div>
+      </div>
+    </nav>
+
+    <div class="container">
+      <h1>ユーザー編集</h1>
+      <%= flash[:notice] %>
+      <hr>
+      <%= render "form", user: @user, url: user_url%>
+      <hr>
+
+      <div class="my-3">
+        <%= link_to "< Back", user_url(@user), class: 'btn btn-link' %>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Home</title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-light bg-light mb-3">
+      <div class="container-fluid">
+        <a href="/tasks" class="navbar-brand">Tasks</a>
+        <div>
+          <%= link_to current_user.name, user_path(session[:user_id]), class: 'btn btn-link' %>
+          <%= link_to "log out", logout_path, method: :delete, class: 'btn btn-outline-danger' %>
+        </div>
+      </div>
+    </nav>
+    
+    <div class="container mb-3">
+      <%= link_to "Create New User", new_user_path, class: 'btn btn-info btn-block' %>
+    </div>
+
+    <h1>Users Info</h1>
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <th scope="col">ID</th>
+          <th scope="col">名前</th>
+          <th scope="col">アドレス</th>
+          <th scope="col">作成日時</th>
+          <th scope="col">更新日時</th>
+          <th scope="col"></th>
+        </thead>
+        
+        <tbody>
+          <% @users.each do |user| %>
+            <tr valign="middle">
+              <td><%= user.id %></td>
+              <td><%= link_to user.name, edit_user_path(user)%></td>
+              <td><%= user.email %></td>
+              <td><%= user.created_at.strftime('%Y.%m.%d %H:%M') %></td>
+              <td><%= user.updated_at.strftime('%Y.%m.%d %H:%M') %></td>
+              <td>
+                <%= link_to "Delete", user_path(user), class: 'btn btn-outline-danger btn-sm', method: :delete, 
+                data: {confirm: "このユーザーを削除します。よろしいですか？"} %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= paginate @users, class: 'mb-3', theme: 'twitter-bootstrap-4'%>
+  
+  </body>
+</html>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -28,6 +28,7 @@
           <th scope="col">ID</th>
           <th scope="col">名前</th>
           <th scope="col">アドレス</th>
+          <th scope="col">タスク数（未着手, 作業中, 完了）</th>
           <th scope="col">作成日時</th>
           <th scope="col">更新日時</th>
           <th scope="col"></th>
@@ -39,6 +40,13 @@
               <td><%= user.id %></td>
               <td><%= link_to user.name, edit_user_path(user)%></td>
               <td><%= user.email %></td>
+              <td align="center">
+                <%= user.tasks.count %>（
+                  <%= user.tasks.where(status: 0).count %>, 
+                  <%= user.tasks.where(status: 1).count %>,
+                  <%= user.tasks.where(status: 2).count %>
+                ）
+              </td>
               <td><%= user.created_at.strftime('%Y.%m.%d %H:%M') %></td>
               <td><%= user.updated_at.strftime('%Y.%m.%d %H:%M') %></td>
               <td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -38,7 +38,7 @@
           <% @users.each do |user| %>
             <tr valign="middle">
               <td><%= user.id %></td>
-              <td><%= link_to user.name, edit_user_path(user)%></td>
+              <td><%= link_to user.name, user_path(user)%></td>
               <td><%= user.email %></td>
               <td align="center">
                 <%= user.tasks.count %>（

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -21,7 +21,7 @@
       <hr>
 
       <div class="my-3">
-        <%= link_to "< Back", login_path, class: 'btn btn-link' %>
+        <%= link_to "< Back", :back, class: 'btn btn-link' %>
       </div>
     </div>
   </body>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,2 +1,28 @@
-<h1>Users#new</h1>
-<p>Find me in app/views/users/new.html.erb</p>
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Edit Task</title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-light bg-light mb-3">
+      <div class="container-fluid">
+        <a href="/" class="navbar-brand">Tasks</a>
+      </div>
+    </nav>
+
+    <div class="container">
+      <h1>ユーザー作成</h1>
+      <%= flash[:notice] %>
+      <hr>
+      <%= render "form", user: @user, url: users_url%>
+      <hr>
+
+      <div class="my-3">
+        <%= link_to "< Back", login_path, class: 'btn btn-link' %>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>User Detail</title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-light bg-light mb-3">
+      <div class="container-fluid">
+        <a href="/" class="navbar-brand">Tasks</a>
+        <div>
+          <%= link_to current_user.name, user_path(session[:user_id]), class: 'btn btn-link' %>
+          <%= link_to "log out", logout_path, method: :delete, class: 'btn btn-outline-danger' %>
+        </div>
+      </div>
+    </nav>
+
+    <div class="container">
+      <h1>アカウント情報</h1>
+      <%= flash[:notice] %>
+      <hr>
+      <p>ユーザー名：<%= @user.name %></p>
+      <p>メールアドレス：<%= @user.email %></p>
+      <p>作成日時：<%= @user.created_at.strftime('%Y.%m.%d %H:%M') %></p>
+      <p>更新日時：<%= @user.updated_at.strftime('%Y.%m.%d %H:%M') %></p>
+      <hr>
+
+      <%= link_to "Edit", edit_user_path(@user), class: 'btn btn-info btn-sm w-25' %>
+      <div class="my-3">
+        <%= link_to "<< Home", root_path, class: 'btn btn-link' %>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,6 +28,7 @@
       <hr>
 
       <%= link_to "Edit", edit_user_path(@user), class: 'btn btn-info btn-sm w-25' %>
+      <%= link_to "User Management", users_path, class: 'btn btn-warning btn-sm w-25' %>
       <div class="my-3">
         <%= link_to "<< Home", root_path, class: 'btn btn-link' %>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,8 +25,37 @@
       <p>メールアドレス：<%= @user.email %></p>
       <p>作成日時：<%= @user.created_at.strftime('%Y.%m.%d %H:%M') %></p>
       <p>更新日時：<%= @user.updated_at.strftime('%Y.%m.%d %H:%M') %></p>
-      <hr>
 
+      <h2>Tasks</h2>
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <th scope="col">タイトル</th>
+            <th scope="col">詳細</th>
+            <th scope="col">進捗</th>
+            <th scope="col">〆切日時</th>
+            <th scope="col">優先度</th>
+            <th scope="col">作成日時</th>
+            <th scope="col">更新日時</th>
+          </thead>
+          
+          <tbody>
+            <% @user.tasks.each do |task| %>
+              <tr>
+                <td><%= link_to task.title, task_path(task)%></td>
+                <td><%= task.description %></td>
+                <td><%= @status[task.status] %></td>
+                <td><%= nil_trans task.date, true %></td>
+                <td><%= @priority_mark[nil_trans task.priority, false, true] %></td>
+                <td><%= task.created_at.strftime('%Y.%m.%d %H:%M') %></td>
+                <td><%= task.updated_at.strftime('%Y.%m.%d %H:%M') %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <hr>
       <%= link_to "Edit", edit_user_path(@user), class: 'btn btn-info btn-sm w-25' %>
       <%= link_to "User Management", users_path, class: 'btn btn-warning btn-sm w-25' %>
       <div class="my-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 Rails.application.routes.draw do
-  get 'users/new'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  
   root "tasks#index"
+
   resources :tasks do
     collection do
       get  "search"
     end
   end
+
+  resources :users
 
   # resourcesを使うフルセットルーティングはいらないので個別指定
   get    '/login',   to: 'sessions#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users
+  scope '/admin' do
+    resources :users
+  end
 
   # resourcesを使うフルセットルーティングはいらないので個別指定
   get    '/login',   to: 'sessions#new'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,18 +9,20 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 3.times do |t|
-    Task.create!(
-        title: "test#{t + 1}",
-        description: "これはテストです（#{t}）",
-        status: t,
-        date: "2022-01-0#{t + 1} 10:00:00", 
-        priority: 3-t,
-        label: 0, 
-        user_id: t+1
-    )
     User.create!(
-        name: "user#{t}",
-        email: "sample#{t}@example.com",
-        password: "hogehoge#{t}"
+        name: "user#{t+1}",
+        email: "sample#{t+1}@example.com",
+        password: "hogehoge#{t+1}"
     )
+    3.times do |n|
+        Task.create!(
+            title: "test#{t+1}-#{n+1}",
+            description: "From seed file; #{t+1}-#{n+1}",
+            status: n,
+            date: "2022-01-0#{t+1} 10:00:00", 
+            priority: 3-n,
+            label: 0, 
+            user_id: t+1
+        )
+    end
 end


### PR DESCRIPTION
- タスク登録フォームのユーザーIDをBE処理にするfix
- step23: ユーザーのCRUD
  - ユーザー一覧・作成・更新・削除の実装
    - 一覧画面上で各ユーザーが持つタスク数を表示
    - そこから各ユーザーのタスク一覧も参照可能に
  - 上記ページのURLには全て/adminが付くようにルーティングを更新
  - ユーザー削除により紐づいたタスクデータは自動で削除される


 indexでタスク数を一覧表示 | 各ユーザーのタスク詳細を表示 
-- | --
![スクリーンショット 2022-09-22 13 20 26](https://user-images.githubusercontent.com/43166752/191657711-4fffb0ef-c582-4d09-9ac0-63afac168b66.png) | ![スクリーンショット 2022-09-22 13 20 59](https://user-images.githubusercontent.com/43166752/191657771-c54ff6ed-9dc4-4a1d-be51-b1b947ada3a3.png)
